### PR TITLE
Link in sqlite3 with condor_cached.

### DIFF
--- a/build/cmake/CondorConfigure.cmake
+++ b/build/cmake/CondorConfigure.cmake
@@ -469,6 +469,7 @@ option(WANT_GLEXEC "Build and install condor glexec functionality" ON)
 option(WANT_MAN_PAGES "Generate man pages as part of the default build" OFF)
 option(ENABLE_JAVA_TESTS "Enable java tests" ON)
 option(WITH_PYTHON_BINDINGS "Support for HTCondor python bindings" ON)
+option(WITH_CACHED "Support for the condor_cached contrib daemon" ON)
 
 #####################################
 # PROPER option
@@ -696,6 +697,29 @@ if (WANT_CONTRIB AND WITH_MANAGEMENT)
     endif()
     add_definitions( -DWANT_CONTRIB )
     add_definitions( -DWITH_MANAGEMENT )
+
+    if (WITH_CACHED)
+        FIND_PATH(SQLITE3_INCLUDE_DIRS sqlite3.h
+            HINTS
+            ${SQLITE3_DIR}
+            $ENV{SQLITE3_DIR}
+            /usr
+            PATH_SUFFIXES include
+        )
+        FIND_LIBRARY(SQLITE3_LIBRARIES sqlite3
+            HINTS
+            ${SQLITE3_DIR}
+            $ENV{SQLITE3_DIR}
+            /usr
+            PATH_SUFFIXES lib lib64 .libs
+        )
+        if (${SQLITE3_LIBRARIES} STREQUAL "SQLITE3_LIBRARIES-NOTFOUND")
+            message(FATAL_ERROR "condor_cached is enabled (-DWITH_CACHED) but sqlite3 libraries are not found on the system.")
+        endif()
+        if (${SQLITE3_INCLUDE_DIRS} STREQUAL "SQLITE3_INCLUDE_DIRS-NOTFOUND")
+            message(FATAL_ERROR "condor_cached is enabled (-DWITH_CACHED) but sqlite3 headers are not found on the system.")
+        endif()
+    endif()
 endif()
 
 message(STATUS "********* External configuration complete (dropping config.h) *********")

--- a/src/condor_contrib/condor_cached/CMakeLists.txt
+++ b/src/condor_contrib/condor_cached/CMakeLists.txt
@@ -16,6 +16,7 @@
  # 
  ############################################################### 
 
-if (NOT WIN_EXEC_NODE_ONLY AND HAVE_SHARED_PORT)
-	condor_exe( condor_cached "condor_cached_main.cpp;cached_server.cpp" ${C_LIBEXEC} "${CONDOR_LIBS}" OFF )
+if (WITH_CACHED)
+	include_directories(${SQLITE3_INCLUDE_DIRS})
+	condor_exe( condor_cached "condor_cached_main.cpp;cached_server.cpp" ${C_LIBEXEC} "${CONDOR_LIBS};${SQLITE3_LIBRARIES}" OFF )
 endif()

--- a/src/condor_contrib/condor_cached/cached_server.cpp
+++ b/src/condor_contrib/condor_cached/cached_server.cpp
@@ -1,11 +1,12 @@
 #include "condor_common.h"
 #include "condor_config.h"
-#include "../condor_daemon_core.V6/condor_daemon_core.h"
+#include "condor_daemon_core.h"
 #include "cached_server.h"
 
-
+#include <sqlite3.h>
 
 CachedServer::CachedServer():
+  m_db(NULL),
   m_registered_handlers(false)
 {
   
@@ -130,9 +131,19 @@ CachedServer::~CachedServer() {
 
 
 void
-CachedServer::InitAndReconfig() {
-  
-  
+CachedServer::InitAndReconfig()
+{
+	m_db_fname = param("CACHED_DATABASE");
+	if (m_db != NULL)
+	{
+		sqlite3_close(m_db);
+	}
+	if (sqlite3_open(m_db_fname.c_str(), &m_db))
+	{
+		dprintf(D_ALWAYS, "Failed to open cached database %s: %s\n", m_db_fname.c_str(), sqlite3_errmsg(m_db));
+		EXCEPT("Failed to open cached database %s: %s\n", m_db_fname.c_str(), sqlite3_errmsg(m_db));
+		sqlite3_close(m_db);
+	}
 }
 
 

--- a/src/condor_contrib/condor_cached/cached_server.h
+++ b/src/condor_contrib/condor_cached/cached_server.h
@@ -1,6 +1,6 @@
 /***************************************************************
  *
- * Copyright (C) 1990-2007, Condor Team, Computer Sciences Department,
+ * Copyright (C) 1990-2014, Condor Team, Computer Sciences Department,
  * University of Wisconsin-Madison, WI.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License"); you
@@ -20,6 +20,7 @@
 #ifndef __CACHED_SERVER_H__
 #define __CACHED_SERVER_H__
 
+struct sqlite3;
 
 class CachedServer: Service {
  public:
@@ -44,7 +45,9 @@ class CachedServer: Service {
    int GetReplicationPolicy(int cmd, Stream *sock);
    int CreateReplica(int cmd, Stream *sock);
    
-    bool m_registered_handlers;
+	std::string m_db_fname;
+	sqlite3 *m_db;
+	bool m_registered_handlers;
     
     
 };

--- a/src/condor_utils/param_info.in
+++ b/src/condor_utils/param_info.in
@@ -6966,6 +6966,13 @@ review=?
 default=1.0
 review=?
 
+# condor_cached contrib params
+[CACHED_DATABASE]
+default=$(SPOOL)/cached.db
+customization=rarely
+type=path
+friendly_name=Location of the condor_cached sqlite DB
+
 # Useful constants
 [MINUTE]
 default=60


### PR DESCRIPTION
Adds the necessary CMake for linking sqlite3.  Added the ability to open / reopen a sqlite3 database during reconfig.
